### PR TITLE
Fix missing return statement

### DIFF
--- a/nobots.go
+++ b/nobots.go
@@ -86,7 +86,7 @@ func (b BotUA) ServeHTTP(w http.ResponseWriter, r *http.Request) (int, error) {
 
 	// Check if the UA is a evil one
 	if b.IsEvil(rua) {
-		serveBomb(w, r, b.UA.bomb)
+		return serveBomb(w, r, b.UA.bomb)
 	}
 
 	// Nothing happens carry on with next stuff


### PR DESCRIPTION
It probably worked before because the extra data written to the response was ignored by the client, but still sent. Also the status code wasn't always 200, and information could leak to bots.